### PR TITLE
Minor improvements

### DIFF
--- a/.github/workflows/publish-alpha-beta.yml
+++ b/.github/workflows/publish-alpha-beta.yml
@@ -21,6 +21,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       
       - run: npm ci
+      - run: npm run test
 
       - name: Create release
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
     
       - run: npm ci
+      - run: npm run test
 
       - name: Create release
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -605,9 +605,9 @@
       "dev": true
     },
     "node_modules/es-abstract": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
-      "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.4.tgz",
+      "integrity": "sha512-flV8e5g9/xulChMG48Fygk1ptpo4lQRJ0eJYtxJFgi7pklLx7EFcOJ34jnvr8pbWlaFN/AT1cZpe0hiFel9Hqg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -621,7 +621,7 @@
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.0",
@@ -2759,9 +2759,9 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
-      "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.4.tgz",
+      "integrity": "sha512-flV8e5g9/xulChMG48Fygk1ptpo4lQRJ0eJYtxJFgi7pklLx7EFcOJ34jnvr8pbWlaFN/AT1cZpe0hiFel9Hqg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -2775,7 +2775,7 @@
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "axios": "0.24.0",
+        "bech32": "1.1.4",
         "bignumber.js": "9.0.1",
         "buffer": "6.0.3",
         "json-bigint": "1.0.0"
@@ -287,6 +288,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/bignumber.js": {
       "version": "9.0.1",
@@ -2519,6 +2525,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "bignumber.js": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "packages": {},
   "dependencies": {
     "axios": "0.24.0",
+    "bech32": "1.1.4",
     "bignumber.js": "9.0.1",
     "buffer": "6.0.3",
     "json-bigint": "1.0.0"

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import { IBech32Address } from "./interface";
 import { Bech32Address } from "./primitives";
 
@@ -7,7 +8,7 @@ import { Bech32Address } from "./primitives";
  export class AccountOnNetwork {
     address: IBech32Address = new Bech32Address("");
     nonce: number = 0;
-    balance: string = "";
+    balance: BigNumber = new BigNumber(0);
     code: string = "";
     userName: string = "";
 
@@ -20,7 +21,7 @@ import { Bech32Address } from "./primitives";
 
         result.address = new Bech32Address(payload["address"] || 0);
         result.nonce = Number(payload["nonce"] || 0);
-        result.balance = (payload["balance"] || 0).toString();
+        result.balance = new BigNumber(payload["balance"] || 0);
         result.code = payload["code"] || "";
         result.userName = payload["username"] || "";
 

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -19,7 +19,7 @@ import { Address } from "./primitives";
     static fromHttpResponse(payload: any): AccountOnNetwork {
         let result = new AccountOnNetwork();
 
-        result.address = new Address(payload["address"] || 0);
+        result.address = new Address(payload["address"] || "");
         result.nonce = Number(payload["nonce"] || 0);
         result.balance = new BigNumber(payload["balance"] || 0);
         result.code = payload["code"] || "";

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,12 +1,12 @@
 import BigNumber from "bignumber.js";
-import { IBech32Address } from "./interface";
-import { Bech32Address } from "./primitives";
+import { IAddress } from "./interface";
+import { Address } from "./primitives";
 
 /**
  * A plain view of an account, as queried from the Network.
  */
  export class AccountOnNetwork {
-    address: IBech32Address = new Bech32Address("");
+    address: IAddress = new Address("");
     nonce: number = 0;
     balance: BigNumber = new BigNumber(0);
     code: string = "";
@@ -19,7 +19,7 @@ import { Bech32Address } from "./primitives";
     static fromHttpResponse(payload: any): AccountOnNetwork {
         let result = new AccountOnNetwork();
 
-        result.address = new Bech32Address(payload["address"] || 0);
+        result.address = new Address(payload["address"] || 0);
         result.nonce = Number(payload["nonce"] || 0);
         result.balance = new BigNumber(payload["balance"] || 0);
         result.code = payload["code"] || "";

--- a/src/apiNetworkProvider.ts
+++ b/src/apiNetworkProvider.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { AccountOnNetwork } from "./accounts";
-import { IBech32Address, IContractQuery, INetworkProvider, ITransaction, IPagination } from "./interface";
+import { IAddress, IContractQuery, INetworkProvider, ITransaction, IPagination } from "./interface";
 import { NetworkConfig } from "./networkConfig";
 import { NetworkStake } from "./networkStake";
 import { NetworkGeneralStatistics } from "./networkGeneralStatistics";
@@ -48,13 +48,13 @@ export class ApiNetworkProvider implements INetworkProvider {
         return stats;
     }
 
-    async getAccount(address: IBech32Address): Promise<AccountOnNetwork> {
+    async getAccount(address: IAddress): Promise<AccountOnNetwork> {
         let response = await this.doGetGeneric(`accounts/${address.bech32()}`);
         let account = AccountOnNetwork.fromHttpResponse(response);
         return account;
     }
 
-    async getFungibleTokensOfAccount(address: IBech32Address, pagination?: IPagination): Promise<FungibleTokenOfAccountOnNetwork[]> {
+    async getFungibleTokensOfAccount(address: IAddress, pagination?: IPagination): Promise<FungibleTokenOfAccountOnNetwork[]> {
         pagination = pagination || defaultPagination;
 
         let url = `accounts/${address.bech32()}/tokens?${this.buildPaginationParams(pagination)}`;
@@ -66,7 +66,7 @@ export class ApiNetworkProvider implements INetworkProvider {
         return tokens;
     }
 
-    async getNonFungibleTokensOfAccount(address: IBech32Address, pagination?: IPagination): Promise<NonFungibleTokenOfAccountOnNetwork[]> {
+    async getNonFungibleTokensOfAccount(address: IAddress, pagination?: IPagination): Promise<NonFungibleTokenOfAccountOnNetwork[]> {
         pagination = pagination || defaultPagination;
 
         let url = `accounts/${address.bech32()}/nfts?${this.buildPaginationParams(pagination)}`;
@@ -78,13 +78,13 @@ export class ApiNetworkProvider implements INetworkProvider {
         return tokens;
     }
 
-    async getFungibleTokenOfAccount(address: IBech32Address, tokenIdentifier: string): Promise<FungibleTokenOfAccountOnNetwork> {
+    async getFungibleTokenOfAccount(address: IAddress, tokenIdentifier: string): Promise<FungibleTokenOfAccountOnNetwork> {
         let response = await this.doGetGeneric(`accounts/${address.bech32()}/tokens/${tokenIdentifier}`);
         let tokenData = FungibleTokenOfAccountOnNetwork.fromHttpResponse(response);
         return tokenData;
     }
 
-    async getNonFungibleTokenOfAccount(address: IBech32Address, collection: string, nonce: number): Promise<NonFungibleTokenOfAccountOnNetwork> {
+    async getNonFungibleTokenOfAccount(address: IAddress, collection: string, nonce: number): Promise<NonFungibleTokenOfAccountOnNetwork> {
         let nonceAsHex = new Nonce(nonce).hex();
         let response = await this.doGetGeneric(`accounts/${address.bech32()}/nfts/${collection}-${nonceAsHex}`);
         let tokenData = NonFungibleTokenOfAccountOnNetwork.fromApiHttpResponse(response);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
 import BigNumber from "bignumber.js";
+import { Address } from "./primitives";
 
 export const MaxUint64AsBigNumber = new BigNumber("18446744073709551615");

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,4 @@ import BigNumber from "bignumber.js";
 import { Address } from "./primitives";
 
 export const MaxUint64AsBigNumber = new BigNumber("18446744073709551615");
+export const EsdtContractAddress = new Address("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u");

--- a/src/contractQueryRequest.ts
+++ b/src/contractQueryRequest.ts
@@ -11,9 +11,9 @@ export class ContractQueryRequest {
         let request: any = {};
         let query = this.query;
         request.scAddress = query.address.bech32();
-        request.caller = query.caller.bech32() ? query.caller.bech32() : undefined;
+        request.caller = query.caller?.bech32() ? query.caller.bech32() : undefined;
         request.funcName = query.func.toString();
-        request.value = query.value.toString();
+        request.value = query.value ? query.value.toString() : undefined;
         request.args = query.getEncodedArguments();
         
         return request;

--- a/src/contractResults.ts
+++ b/src/contractResults.ts
@@ -1,6 +1,6 @@
-import { IBech32Address } from "./interface";
+import { IAddress } from "./interface";
 import { TransactionLogs } from "./transactionLogs";
-import { Bech32Address } from "./primitives";
+import { Address } from "./primitives";
 
 export class ContractResults {
     readonly items: ContractResultItem[];
@@ -28,8 +28,8 @@ export class ContractResultItem {
     hash: string = "";
     nonce: number = 0;
     value: string = "";
-    receiver: IBech32Address = new Bech32Address("");
-    sender: IBech32Address = new Bech32Address("");
+    receiver: IAddress = new Address("");
+    sender: IAddress = new Address("");
     data: string = "";
     previousHash: string = "";
     originalHash: string = "";
@@ -63,8 +63,8 @@ export class ContractResultItem {
         item.hash = response.hash;
         item.nonce = Number(response.nonce || 0);
         item.value = (response.value || 0).toString();
-        item.receiver = new Bech32Address(response.receiver);
-        item.sender = new Bech32Address(response.sender);
+        item.receiver = new Address(response.receiver);
+        item.sender = new Address(response.sender);
         item.previousHash = response.prevTxHash;
         item.originalHash = response.originalTxHash;
         item.gasLimit = Number(response.gasLimit || 0);

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -36,27 +36,27 @@ export interface INetworkProvider {
     /**
      * Fetches the state of an account.
      */
-    getAccount(address: IBech32Address): Promise<AccountOnNetwork>;
+    getAccount(address: IAddress): Promise<AccountOnNetwork>;
 
     /**
      * Fetches data about the fungible tokens held by an account.
      */
-    getFungibleTokensOfAccount(address: IBech32Address, pagination?: IPagination): Promise<FungibleTokenOfAccountOnNetwork[]>;
+    getFungibleTokensOfAccount(address: IAddress, pagination?: IPagination): Promise<FungibleTokenOfAccountOnNetwork[]>;
 
     /**
      * Fetches data about the non-fungible tokens held by account.
      */
-    getNonFungibleTokensOfAccount(address: IBech32Address, pagination?: IPagination): Promise<NonFungibleTokenOfAccountOnNetwork[]>;
+    getNonFungibleTokensOfAccount(address: IAddress, pagination?: IPagination): Promise<NonFungibleTokenOfAccountOnNetwork[]>;
 
     /**
      * Fetches data about a specific fungible token held by an account.
      */
-    getFungibleTokenOfAccount(address: IBech32Address, tokenIdentifier: string): Promise<FungibleTokenOfAccountOnNetwork>;
+    getFungibleTokenOfAccount(address: IAddress, tokenIdentifier: string): Promise<FungibleTokenOfAccountOnNetwork>;
 
     /**
      * Fetches data about a specific non-fungible token (instance) held by an account.
      */
-    getNonFungibleTokenOfAccount(address: IBech32Address, collection: string, nonce: number): Promise<NonFungibleTokenOfAccountOnNetwork>;
+    getNonFungibleTokenOfAccount(address: IAddress, collection: string, nonce: number): Promise<NonFungibleTokenOfAccountOnNetwork>;
 
     /**
      * Fetches the state of a transaction.
@@ -111,10 +111,10 @@ export interface INetworkProvider {
 }
 
 export interface IContractQuery {
-    address: IBech32Address;
-    caller: IBech32Address;
+    address: IAddress;
+    caller?: IAddress;
     func: { toString(): string; };
-    value: { toString(): string; };
+    value?: { toString(): string; };
     getEncodedArguments(): string[];
 }
 
@@ -127,4 +127,4 @@ export interface ITransaction {
     toSendable(): any;
 }
 
-export interface IBech32Address { bech32(): string; }
+export interface IAddress { bech32(): string; }

--- a/src/primitives.spec.ts
+++ b/src/primitives.spec.ts
@@ -1,0 +1,15 @@
+import { assert } from "chai";
+import { Address } from "./primitives";
+
+describe("test primitives", function () {
+    it("should create address from bech32 and from pubkey", async function () {
+        let aliceBech32 = "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th";
+        let bobBech32 = "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx";
+        let alicePubkey = Buffer.from("0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1", "hex");
+        let bobPubkey = Buffer.from("8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8", "hex");
+
+        assert.equal(new Address(aliceBech32).bech32(), Address.fromPubkey(alicePubkey).bech32());
+        assert.equal(new Address(bobBech32).bech32(), Address.fromPubkey(bobPubkey).bech32());
+    });
+});
+

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,10 +1,22 @@
-import { IBech32Address } from "./interface";
+import * as bech32 from "bech32";
+import { IAddress } from "./interface";
 
-export class Bech32Address implements IBech32Address {
+/**
+ * The human-readable-part of the bech32 addresses.
+ */
+const HRP = "erd";
+
+export class Address implements IAddress {
     private readonly value: string;
 
     constructor(value: string) {
         this.value = value;
+    }
+
+    static fromPubkey(pubkey: Buffer): IAddress {
+        let words = bech32.toWords(pubkey);
+        let address = bech32.encode(HRP, words);
+        return new Address(address);
     }
 
     bech32(): string {

--- a/src/providers.dev.net.spec.ts
+++ b/src/providers.dev.net.spec.ts
@@ -164,12 +164,10 @@ describe("test network providers on devnet: Proxy and API", function () {
 
         for (const identifier of identifiers) {
             let apiResponse = await apiProvider.getDefinitionOfFungibleToken(identifier);
+            let proxyResponse = await proxyProvider.getDefinitionOfFungibleToken(identifier);
 
             assert.equal(apiResponse.identifier, identifier);
-
-            // TODO: Uncomment after implementing the function in the proxy provider.
-            // let proxyResponse = await proxyProvider.getDefinitionOfFungibleToken(identifier);
-            // assert.deepEqual(apiResponse, proxyResponse);
+            assert.deepEqual(apiResponse, proxyResponse);
         }
     });
 

--- a/src/providers.dev.net.spec.ts
+++ b/src/providers.dev.net.spec.ts
@@ -178,12 +178,10 @@ describe("test network providers on devnet: Proxy and API", function () {
 
         for (const collection of collections) {
             let apiResponse = await apiProvider.getDefinitionOfTokenCollection(collection);
+            let proxyResponse = await proxyProvider.getDefinitionOfTokenCollection(collection);
 
             assert.equal(apiResponse.collection, collection);
-
-            // TODO: Uncomment after implementing the function in the proxy provider.
-            // let proxyResponse = await proxyProvider.getDefinitionOfTokenCollection(identifier);
-            // assert.deepEqual(apiResponse, proxyResponse);
+            assert.deepEqual(apiResponse, proxyResponse);
         }
     });
 

--- a/src/providers.dev.net.spec.ts
+++ b/src/providers.dev.net.spec.ts
@@ -2,16 +2,16 @@ import { assert } from "chai";
 import { INetworkProvider } from "./interface";
 import { TransactionOnNetwork } from "./transactions";
 import { TransactionStatus } from "./transactionStatus";
-import { Bech32Address, Nonce } from "./primitives";
+import { Address } from "./primitives";
 import { MockQuery } from "./testscommon/dummyQuery";
 import { ApiNetworkProvider } from "./apiNetworkProvider";
 import { ProxyNetworkProvider } from "./proxyNetworkProvider";
 
 describe("test network providers on devnet: Proxy and API", function () {
-    let alice = new Bech32Address("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
-    let bob = new Bech32Address("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx");
-    let carol = new Bech32Address("erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
-    let dan = new Bech32Address("erd1kyaqzaprcdnv4luvanah0gfxzzsnpaygsy6pytrexll2urtd05ts9vegu7");
+    let alice = new Address("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
+    let bob = new Address("erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx");
+    let carol = new Address("erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8");
+    let dan = new Address("erd1kyaqzaprcdnv4luvanah0gfxzzsnpaygsy6pytrexll2urtd05ts9vegu7");
 
     let apiProvider: INetworkProvider = new ApiNetworkProvider("https://devnet-api.elrond.com", { timeout: 10000 });
     let proxyProvider: INetworkProvider = new ProxyNetworkProvider("https://devnet-gateway.elrond.com", { timeout: 10000 });
@@ -210,7 +210,7 @@ describe("test network providers on devnet: Proxy and API", function () {
 
         // Query: get sum (of adder contract)
         let query = new MockQuery({
-            address: new Bech32Address("erd1qqqqqqqqqqqqqpgquykqja5c4v33zdmnwglj3jphqwrelzdn396qlc9g33"),
+            address: new Address("erd1qqqqqqqqqqqqqpgquykqja5c4v33zdmnwglj3jphqwrelzdn396qlc9g33"),
             func: "getSum"
         });
 
@@ -226,7 +226,7 @@ describe("test network providers on devnet: Proxy and API", function () {
 
         // Query: increment counter
         query = new MockQuery({
-            address: new Bech32Address("erd1qqqqqqqqqqqqqpgqzeq07xvhs5g7cg4ama85upaqarrcgu49396q0gz4yf"),
+            address: new Address("erd1qqqqqqqqqqqqqpgqzeq07xvhs5g7cg4ama85upaqarrcgu49396q0gz4yf"),
             func: "increment",
             args: []
         });
@@ -247,7 +247,7 @@ describe("test network providers on devnet: Proxy and API", function () {
 
         // Query: issue ESDT
         let query = new MockQuery({
-            address: new Bech32Address("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"),
+            address: new Address("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"),
             func: "issue",
             value: "50000000000000000",
             args: [

--- a/src/proxyNetworkProvider.ts
+++ b/src/proxyNetworkProvider.ts
@@ -140,11 +140,18 @@ export class ProxyNetworkProvider implements INetworkProvider {
         return definition;
     }
 
-    async getDefinitionOfTokenCollection(_collection: string): Promise<DefinitionOfTokenCollectionOnNetwork> {
-        // TODO: Implement wrt.:
-        // https://github.com/ElrondNetwork/api.elrond.com/blob/main/src/endpoints/collections/collection.service.ts
-        // https://docs.elrond.com/developers/esdt-tokens/#get-esdt-token-properties
-        throw new Error("Method not implemented.");
+    async getDefinitionOfTokenCollection(collection: string): Promise<DefinitionOfTokenCollectionOnNetwork> {
+        let encodedCollection = Buffer.from(collection).toString("hex");
+
+        let queryResponse = await this.queryContract({
+            address: EsdtContractAddress,
+            func: "getTokenProperties",
+            getEncodedArguments: () => [encodedCollection]
+        });
+
+        let dataParts = queryResponse.getReturnDataParts();
+        let definition = DefinitionOfTokenCollectionOnNetwork.fromResponseOfGetTokenProperties(collection, dataParts);
+        return definition;
     }
 
     async getNonFungibleToken(_collection: string, _nonce: number): Promise<NonFungibleTokenOfAccountOnNetwork> {

--- a/src/proxyNetworkProvider.ts
+++ b/src/proxyNetworkProvider.ts
@@ -13,6 +13,7 @@ import { NetworkStatus } from "./networkStatus";
 import { ContractQueryResponse } from "./contractQueryResponse";
 import { DefinitionOfFungibleTokenOnNetwork, DefinitionOfTokenCollectionOnNetwork } from "./tokenDefinitions";
 import { ContractQueryRequest } from "./contractQueryRequest";
+import { EsdtContractAddress } from "./constants";
 
 // TODO: Find & remove duplicate code between "ProxyNetworkProvider" and "ApiNetworkProvider".
 export class ProxyNetworkProvider implements INetworkProvider {
@@ -125,10 +126,18 @@ export class ProxyNetworkProvider implements INetworkProvider {
         }
     }
 
-    async getDefinitionOfFungibleToken(_tokenIdentifier: string): Promise<DefinitionOfFungibleTokenOnNetwork> {
-        // TODO: Implement wrt.:
-        // https://github.com/ElrondNetwork/api.elrond.com/blob/main/src/endpoints/esdt/esdt.service.ts#L221
-        throw new Error("Method not implemented.");
+    async getDefinitionOfFungibleToken(tokenIdentifier: string): Promise<DefinitionOfFungibleTokenOnNetwork> {
+        let encodedTokenIdentifier = Buffer.from(tokenIdentifier).toString("hex");
+
+        let queryResponse = await this.queryContract({
+            address: EsdtContractAddress,
+            func: "getTokenProperties",
+            getEncodedArguments: () => [encodedTokenIdentifier]
+        });
+
+        let dataParts = queryResponse.getReturnDataParts();
+        let definition = DefinitionOfFungibleTokenOnNetwork.fromResponseOfGetTokenProperties(tokenIdentifier, dataParts);
+        return definition;
     }
 
     async getDefinitionOfTokenCollection(_collection: string): Promise<DefinitionOfTokenCollectionOnNetwork> {

--- a/src/proxyNetworkProvider.ts
+++ b/src/proxyNetworkProvider.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { AccountOnNetwork } from "./accounts";
-import { IBech32Address, IContractQuery, INetworkProvider, IPagination, ITransaction } from "./interface";
+import { IAddress, IContractQuery, INetworkProvider, IPagination, ITransaction } from "./interface";
 import { NetworkConfig } from "./networkConfig";
 import { NetworkStake } from "./networkStake";
 import { NetworkGeneralStatistics } from "./networkGeneralStatistics";
@@ -48,13 +48,13 @@ export class ProxyNetworkProvider implements INetworkProvider {
         throw new Error("Method not implemented.");
     }
 
-    async getAccount(address: IBech32Address): Promise<AccountOnNetwork> {
+    async getAccount(address: IAddress): Promise<AccountOnNetwork> {
         let response = await this.doGetGeneric(`address/${address.bech32()}`);
         let account = AccountOnNetwork.fromHttpResponse(response.account);
         return account;
     }
 
-    async getFungibleTokensOfAccount(address: IBech32Address, _pagination?: IPagination): Promise<FungibleTokenOfAccountOnNetwork[]> {
+    async getFungibleTokensOfAccount(address: IAddress, _pagination?: IPagination): Promise<FungibleTokenOfAccountOnNetwork[]> {
         let url = `address/${address.bech32()}/esdt`;
         let response = await this.doGetGeneric(url);
         let responseItems: any[] = Object.values(response.esdts);
@@ -67,7 +67,7 @@ export class ProxyNetworkProvider implements INetworkProvider {
         return tokens;
     }
 
-    async getNonFungibleTokensOfAccount(address: IBech32Address, _pagination?: IPagination): Promise<NonFungibleTokenOfAccountOnNetwork[]> {
+    async getNonFungibleTokensOfAccount(address: IAddress, _pagination?: IPagination): Promise<NonFungibleTokenOfAccountOnNetwork[]> {
         let url = `address/${address.bech32()}/esdt`;
         let response = await this.doGetGeneric(url);
         let responseItems: any[] = Object.values(response.esdts);
@@ -80,13 +80,13 @@ export class ProxyNetworkProvider implements INetworkProvider {
         return tokens;
     }
 
-    async getFungibleTokenOfAccount(address: IBech32Address, tokenIdentifier: string): Promise<FungibleTokenOfAccountOnNetwork> {
+    async getFungibleTokenOfAccount(address: IAddress, tokenIdentifier: string): Promise<FungibleTokenOfAccountOnNetwork> {
         let response = await this.doGetGeneric(`address/${address.bech32()}/esdt/${tokenIdentifier}`);
         let tokenData = FungibleTokenOfAccountOnNetwork.fromHttpResponse(response.tokenData);
         return tokenData;
     }
 
-    async getNonFungibleTokenOfAccount(address: IBech32Address, collection: string, nonce: number): Promise<NonFungibleTokenOfAccountOnNetwork> {
+    async getNonFungibleTokenOfAccount(address: IAddress, collection: string, nonce: number): Promise<NonFungibleTokenOfAccountOnNetwork> {
         let response = await this.doGetGeneric(`address/${address.bech32()}/nft/${collection}/nonce/${nonce.valueOf()}`);
         let tokenData = NonFungibleTokenOfAccountOnNetwork.fromProxyHttpResponseByNonce(response.tokenData);
         return tokenData;

--- a/src/proxyNetworkProvider.ts
+++ b/src/proxyNetworkProvider.ts
@@ -127,30 +127,27 @@ export class ProxyNetworkProvider implements INetworkProvider {
     }
 
     async getDefinitionOfFungibleToken(tokenIdentifier: string): Promise<DefinitionOfFungibleTokenOnNetwork> {
-        let encodedTokenIdentifier = Buffer.from(tokenIdentifier).toString("hex");
-
-        let queryResponse = await this.queryContract({
-            address: EsdtContractAddress,
-            func: "getTokenProperties",
-            getEncodedArguments: () => [encodedTokenIdentifier]
-        });
-
-        let dataParts = queryResponse.getReturnDataParts();
-        let definition = DefinitionOfFungibleTokenOnNetwork.fromResponseOfGetTokenProperties(tokenIdentifier, dataParts);
+        let properties = await this.getTokenProperties(tokenIdentifier);
+        let definition = DefinitionOfFungibleTokenOnNetwork.fromResponseOfGetTokenProperties(tokenIdentifier, properties);
         return definition;
     }
 
-    async getDefinitionOfTokenCollection(collection: string): Promise<DefinitionOfTokenCollectionOnNetwork> {
-        let encodedCollection = Buffer.from(collection).toString("hex");
+    private async getTokenProperties(identifier: string): Promise<Buffer[]> {
+        let encodedIdentifier = Buffer.from(identifier).toString("hex");
 
         let queryResponse = await this.queryContract({
             address: EsdtContractAddress,
             func: "getTokenProperties",
-            getEncodedArguments: () => [encodedCollection]
+            getEncodedArguments: () => [encodedIdentifier]
         });
 
-        let dataParts = queryResponse.getReturnDataParts();
-        let definition = DefinitionOfTokenCollectionOnNetwork.fromResponseOfGetTokenProperties(collection, dataParts);
+        let properties = queryResponse.getReturnDataParts();
+        return properties;
+    }
+
+    async getDefinitionOfTokenCollection(collection: string): Promise<DefinitionOfTokenCollectionOnNetwork> {
+        let properties = await this.getTokenProperties(collection);
+        let definition = DefinitionOfTokenCollectionOnNetwork.fromResponseOfGetTokenProperties(collection, properties);
         return definition;
     }
 

--- a/src/testscommon/dummyQuery.ts
+++ b/src/testscommon/dummyQuery.ts
@@ -1,9 +1,9 @@
-import { IBech32Address, IContractQuery } from "../interface";
-import { Bech32Address } from "../primitives";
+import { IAddress, IContractQuery } from "../interface";
+import { Address } from "../primitives";
 
 export class MockQuery implements IContractQuery {
-    caller: IBech32Address = new Bech32Address("");
-    address: IBech32Address = new Bech32Address("");
+    caller: IAddress = new Address("");
+    address: IAddress = new Address("");
     func: string = "";
     args: string[] = [];
     value: string = "";

--- a/src/tokenDefinitions.ts
+++ b/src/tokenDefinitions.ts
@@ -1,12 +1,12 @@
 import { BigNumber } from "bignumber.js";
-import { Bech32Address } from "./primitives";
-import { IBech32Address } from "./interface";
+import { Address } from "./primitives";
+import { IAddress } from "./interface";
 
 export class DefinitionOfFungibleTokenOnNetwork {
     identifier: string = "";
     name: string = "";
     ticker: string = "";
-    owner: IBech32Address = new Bech32Address("");
+    owner: IAddress = new Address("");
     decimals: number = 0;
     supply: BigNumber = new BigNumber(0);
     isPaused: boolean = false;
@@ -25,7 +25,7 @@ export class DefinitionOfFungibleTokenOnNetwork {
         result.identifier = payload.identifier || "";
         result.name = payload.name || "";
         result.ticker = payload.ticker || "";
-        result.owner = new Bech32Address(payload.owner || "");
+        result.owner = new Address(payload.owner || "");
         result.decimals = payload.decimals || 0;
         result.supply = new BigNumber(payload.supply || "0");
         result.isPaused = payload.isPaused || false;
@@ -47,7 +47,7 @@ export class DefinitionOfTokenCollectionOnNetwork {
     type: string = "";
     name: string = "";
     ticker: string = "";
-    owner: IBech32Address = new Bech32Address("");
+    owner: IAddress = new Address("");
     decimals: number = 0;
     canPause: boolean = false;
     canFreeze: boolean = false;
@@ -61,7 +61,7 @@ export class DefinitionOfTokenCollectionOnNetwork {
         result.type = payload.type || "";
         result.name = payload.name || "";
         result.ticker = payload.ticker || "";
-        result.owner = new Bech32Address(payload.owner || "");
+        result.owner = new Address(payload.owner || "");
         result.decimals = payload.decimals || 0;
         result.canPause = payload.canPause || false;
         result.canFreeze = payload.canFreeze || false;

--- a/src/tokenDefinitions.ts
+++ b/src/tokenDefinitions.ts
@@ -36,9 +36,56 @@ export class DefinitionOfFungibleTokenOnNetwork {
         result.canPause = payload.canPause || false;
         result.canFreeze = payload.canFreeze || false;
         result.canWipe = payload.canWipe || false;
-        result.canAddSpecialRoles = payload.canAddSpecialRoles || false;
 
         return result;
+    }
+
+    /**
+     * The implementation has been moved here from the following location:
+     * https://github.com/ElrondNetwork/elrond-sdk-erdjs/blob/release/v9/src/token.ts
+     */
+    static fromResponseOfGetTokenProperties(identifier: string, data: Buffer[]): DefinitionOfFungibleTokenOnNetwork {
+        let result = new DefinitionOfFungibleTokenOnNetwork();
+
+        let [tokenName, _tokenType, owner, supply, ...propertiesBuffers] = data;
+        let properties = this.parseTokenProperties(propertiesBuffers);
+
+        result.identifier = identifier;
+        result.name = tokenName.toString();
+        result.ticker = identifier;
+        result.owner = Address.fromPubkey(owner);
+        result.decimals = properties.NumDecimals.toNumber();
+        result.supply = new BigNumber(supply.toString()).shiftedBy(-result.decimals);
+        result.isPaused = properties.IsPaused;
+        result.canUpgrade = properties.CanUpgrade;
+        result.canMint = properties.CanMint;
+        result.canBurn = properties.CanBurn;
+        result.canChangeOwner = properties.CanChangeOwner;
+        result.canPause = properties.CanPause;
+        result.canFreeze = properties.CanFreeze;
+        result.canWipe = properties.CanWipe;
+
+        return result;
+    }
+
+    private static parseTokenProperties(propertiesBuffers: Buffer[]): Record<string, any> {
+        let properties: Record<string, any> = {};
+
+        for (let buffer of propertiesBuffers) {
+            let [name, value] = buffer.toString().split("-");
+            properties[name] = this.parseValueOfTokenProperty(value);
+        }
+
+        return properties;
+    }
+
+    // This only handles booleans and numbers.
+    private static parseValueOfTokenProperty(value: string): any {
+        switch (value) {
+            case "true": return true;
+            case "false": return false;
+            default: return new BigNumber(value);
+        }
     }
 }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "bignumber.js";
-import { Bech32Address, Nonce } from "./primitives";
-import { IBech32Address } from "./interface";
+import { Address, Nonce } from "./primitives";
+import { IAddress } from "./interface";
 
 export class FungibleTokenOfAccountOnNetwork {
     identifier: string = "";
@@ -24,7 +24,7 @@ export class NonFungibleTokenOfAccountOnNetwork {
     nonce: number = 0;
     type: string = "";
     name: string = "";
-    creator: IBech32Address = new Bech32Address("");
+    creator: IAddress = new Address("");
     supply: BigNumber = new BigNumber(0);
     decimals: number = 0;
     royalties: BigNumber = new BigNumber(0);
@@ -73,7 +73,7 @@ export class NonFungibleTokenOfAccountOnNetwork {
         result.nonce = payload.nonce || 0;
         result.type = payload.type || "";
         result.name = payload.name || "";
-        result.creator = new Bech32Address(payload.creator || "");
+        result.creator = new Address(payload.creator || "");
         result.decimals = Number(payload.decimals || 0);
         result.supply = new BigNumber(payload.balance || 1);
         result.royalties = new BigNumber(payload.royalties || 0);

--- a/src/transactionEvents.ts
+++ b/src/transactionEvents.ts
@@ -1,8 +1,8 @@
-import { IBech32Address } from "./interface";
-import { Bech32Address } from "./primitives";
+import { IAddress } from "./interface";
+import { Address } from "./primitives";
 
 export class TransactionEvent {
-    address: IBech32Address = new Bech32Address("");
+    address: IAddress = new Address("");
     identifier: string = "";
     topics: TransactionEventTopic[] = [];
     data: string = "";
@@ -18,7 +18,7 @@ export class TransactionEvent {
         data: string
     }): TransactionEvent {
         let result = new TransactionEvent();
-        result.address = new Bech32Address(responsePart.address);
+        result.address = new Address(responsePart.address);
         result.identifier = responsePart.identifier || "";
         result.topics = (responsePart.topics || []).map(topic => new TransactionEventTopic(topic));
         result.data = Buffer.from(responsePart.data || "", "base64").toString();

--- a/src/transactionLogs.ts
+++ b/src/transactionLogs.ts
@@ -1,10 +1,10 @@
 import { ErrUnexpectedCondition } from "./errors";
-import { IBech32Address } from "./interface";
-import { Bech32Address } from "./primitives";
+import { IAddress } from "./interface";
+import { Address } from "./primitives";
 import { TransactionEvent } from "./transactionEvents";
 
 export class TransactionLogs {
-    address: IBech32Address = new Bech32Address("");
+    address: IAddress = new Address("");
     events: TransactionEvent[] = [];
 
     constructor(init?: Partial<TransactionLogs>) {
@@ -13,7 +13,7 @@ export class TransactionLogs {
 
     static fromHttpResponse(logs: any): TransactionLogs {
         let result = new TransactionLogs();
-        result.address = new Bech32Address(logs.address);
+        result.address = new Address(logs.address);
         result.events = (logs.events || []).map((event: any) => TransactionEvent.fromHttpResponse(event));
         
         return result;

--- a/src/transactionReceipt.ts
+++ b/src/transactionReceipt.ts
@@ -1,9 +1,9 @@
-import { IBech32Address } from "./interface";
-import { Bech32Address } from "./primitives";
+import { IAddress } from "./interface";
+import { Address } from "./primitives";
 
 export class TransactionReceipt {
     value: string = "";
-    sender: IBech32Address = new Bech32Address("");
+    sender: IAddress = new Address("");
     data: string = "";
     hash: string = "";
 
@@ -16,7 +16,7 @@ export class TransactionReceipt {
         let receipt = new TransactionReceipt();
 
         receipt.value = (response.value || 0).toString();
-        receipt.sender = new Bech32Address(response.sender);
+        receipt.sender = new Address(response.sender);
         receipt.data = response.data;
         receipt.hash = response.txHash;
 

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -1,7 +1,7 @@
 import { TransactionStatus } from "./transactionStatus";
 import { ContractResults } from "./contractResults";
-import { Bech32Address } from "./primitives";
-import { IBech32Address } from "./interface";
+import { Address } from "./primitives";
+import { IAddress } from "./interface";
 import { TransactionCompletionStrategyOnAPI, TransactionCompletionStrategyOnProxy } from "./transactionCompletionStrategy";
 import { TransactionLogs } from "./transactionLogs";
 import { TransactionReceipt } from "./transactionReceipt";
@@ -14,8 +14,8 @@ export class TransactionOnNetwork {
     round: number = 0;
     epoch: number = 0;
     value: string = "";
-    receiver: IBech32Address = new Bech32Address("");
-    sender: IBech32Address = new Bech32Address("");
+    receiver: IAddress = new Address("");
+    sender: IAddress = new Address("");
     gasLimit: number = 0;
     gasPrice: number = 0;
     data: Buffer = Buffer.from([]);
@@ -60,8 +60,8 @@ export class TransactionOnNetwork {
         result.round = response.round;
         result.epoch = response.epoch || 0;
         result.value = (response.value || 0).toString();
-        result.sender = new Bech32Address(response.sender);
-        result.receiver = new Bech32Address(response.receiver);
+        result.sender = new Address(response.sender);
+        result.receiver = new Address(response.receiver);
         result.gasPrice = response.gasPrice || 0;
         result.gasLimit = response.gasLimit || 0;
         result.data = Buffer.from(response.data || "", "base64");


### PR DESCRIPTION
 - `Account.balance` as `BigNumber`.
 - Rename class (`Bech32Address` to `Address`).
 - Implement `ProxyNetworkProvider.getDefinitionOfFungibleToken()` (original implementation in erdjs, by @claudiu725, moved here).
 - Implement `ProxyNetworkProvider.getDefinitionOfTokenCollection()` (original implementation in erdjs, by @claudiu725, moved here).

Reference:
 - https://github.com/ElrondNetwork/elrond-sdk-erdjs/blob/release/v9/src/token.ts

Reason for the code movement (parsing token properties etc.): generally, users retrieve token definitions using the network providers. Thus, the logic was needed here (so that `ProxyProvider` would behave similar to `ApiProvider`). On the other hand, not needed in erdjs: for ABI-informed interaction with the ESDT system smart contract, one could choose to use the _Contract Wrappers_ instead: https://github.com/ElrondNetwork/elrond-sdk-erdjs-contract-wrappers.